### PR TITLE
docs: adding fcc developer quiz site to repositories-list

### DIFF
--- a/repositories-list.md
+++ b/repositories-list.md
@@ -24,3 +24,4 @@ Templates for making issues and pull requests.
 
 - [Virtual Coffee / virtualcoffee.io](https://github.com/Virtual-Coffee/virtualcoffee.io)
 - [Virtual Coffee / podcast transcripts](https://github.com/Virtual-Coffee/podcast-transcripts)
+- [freeCodeCamp's Developer Quiz Site](https://developerquiz.org/)

--- a/repositories-list.md
+++ b/repositories-list.md
@@ -24,4 +24,4 @@ Templates for making issues and pull requests.
 
 - [Virtual Coffee / virtualcoffee.io](https://github.com/Virtual-Coffee/virtualcoffee.io)
 - [Virtual Coffee / podcast transcripts](https://github.com/Virtual-Coffee/podcast-transcripts)
-- [freeCodeCamp's Developer Quiz Site](https://developerquiz.org/)
+- [freeCodeCamp's Developer Quiz Site](https://github.com/freeCodeCamp/Developer_Quiz_Site)


### PR DESCRIPTION
## Type of Contribution

Check the item(s) that applies.

- [ ] 🌱 Practice Open Source
- [x] 📃 Repositories List

### If your type of contribution is Repositories List, check items in the repository checklist below that apply.

⚠️ *We only accept PRs where most of the items are checked*

- [x] Relevant name
- [x] Description
- [x] Relevant tags
- [x] README.md file
- [x] CONTRIBUTIONS.md/CONTRIBUTING.md file
- [x] Open source license
- [x] Code of Conduct (COC)
- [x] Issue and Pull Request templates

## Description

This PR adds freeCodeCamp's developer quiz site to the repository list. 
