### PR TITLE
Add Meg to Preptember participants

### DIFF
--- a/preptember-participants-2024.md
+++ b/preptember-participants-2024.md
@@ -6,3 +6,4 @@
 
 - [Ayu Adiati](https://github.com/adiati98) | Black Forest cake
 - [Christine Belzie](https://github.com/CBID2) | Red Velvet cake
+- [Meg Gutshall](https://github.com/meg-gutshall) | ICE CREAM!!!! 🍨🍨


### PR DESCRIPTION
## Slack Handle

Meg

> [!Warning]
> Only PRs from existing Virtual Coffee members will be accepted.

## Linked Issue

Resolves #42 

## Type of Contribution

- [x] 🌱 Practice Open Source
- [ ] 📃 Repositories List

## Description

This PR adds Meg to the Preptember participants list.
