### PR TITLE
add Danielle to Preptember participants

### DIFF
--- a/preptember-participants-2024.md
+++ b/preptember-participants-2024.md
@@ -7,3 +7,4 @@
 - [Ayu Adiati](https://github.com/adiati98) | Black Forest cake
 - [Christine Belzie](https://github.com/CBID2) | Red Velvet cake
 - [Meg Gutshall](https://github.com/meg-gutshall) | ICE CREAM!!!! 🍨🍨
+- [Danielle Andrews](https://github.com/DrAcula27) | Cookie Cake 🍪


### PR DESCRIPTION
## Slack Handle
Danielle Andrews

> [!Warning]
> Only PRs from existing Virtual Coffee members will be accepted.

## Linked Issue

Closes #46 

## Type of Contribution

- [x] 🌱 Practice Open Source
- [ ] 📃 Repositories List

## Description

This PR adds Danielle to the Preptember participants.