### PR TITLE
Change 'Slack Handle' to 'Slack Display Name'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-## Slack Handle
+## Slack Display Name
 
- <!-- Please provide your Slack handle at Virtual Coffee for us to confirm. -->
+ <!-- Please provide your Slack Display Name at Virtual Coffee for us to confirm. -->
 
 > [!Warning]
 > Only PRs from existing Virtual Coffee members will be accepted.


### PR DESCRIPTION
## Slack Handle

Meg Gutshall

> [!Warning]
> Only PRs from existing Virtual Coffee members will be accepted.

## Linked Issue

Resolves #54 

## Description

Makes PR template clearer for contributors
